### PR TITLE
If the translation field in the database is not NULL the _() method thin...

### DIFF
--- a/lib/tasks/sync_po_to_db.rake
+++ b/lib/tasks/sync_po_to_db.rake
@@ -30,6 +30,9 @@ task :sync_po_to_db => :environment do
       next if key.translations.detect{|text| text.locale == locale}
 
       #store translations
+      # make sure we store nil (NULL) values if msgstr is blank
+      # so that the _() method will see that the string is not translated
+      t.msgstr.blank? ? t.msgstr = nil : t.msgstr = t.msgstr
       puts "Creating text #{locale}:#{t.msgstr}"
       key.translations.create!(:locale=>locale, :text=>t.msgstr)
     end


### PR DESCRIPTION
...k the string is translated, and return a blank string instead if the fallback msgid. Setting the msgstr to nil make sure that we get NULL values in the db which we want.
